### PR TITLE
net/gcoap: Improve DTLS integration

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -38,7 +38,9 @@ static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
                           sock_udp_ep_t *remote);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
+#ifdef MODULE_SOCK_DTLS
 static int _get_psk_params(psk_params_t *psk);
+#endif
 
 /* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
@@ -55,6 +57,7 @@ static gcoap_listener_t _listener = {
 /* Counts requests sent by CLI. */
 static uint16_t req_count = 0;
 
+#ifdef MODULE_SOCK_DTLS
 static tlsman_handler_t credentials_handler = {
     .get_psk_params = _get_psk_params,
     .get_ecdsa_params = NULL,
@@ -71,6 +74,7 @@ static int _get_psk_params(psk_params_t *psk)
     psk->hint_len = 0;
     return 0;
 }
+#endif
 
 /*
  * Response callback.
@@ -335,6 +339,8 @@ int gcoap_cli_cmd(int argc, char **argv)
 
 void gcoap_cli_init(void)
 {
+#ifdef MODULE_SOCK_DTLS
     tlsman_set_credentials_handler(&credentials_handler);
+#endif
     gcoap_register_listener(&_listener);
 }

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -89,7 +89,8 @@ static int _read(struct dtls_context_t *ctx, session_t *session, uint8_t *buf,
         msg.content.value = -ENOBUFS;
     }
     else {
-        memcpy(sock->buf, buf, len);
+        /* memmove instead of memcpy because memory may overlap */
+        memmove(sock->buf, buf, len);
         msg.content.value = len;
     }
     mbox_put(&sock->mbox, &msg);

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -220,6 +220,9 @@
 #include "net/ipv6/addr.h"
 #include "net/sock/udp.h"
 #include "net/nanocoap.h"
+#ifdef MODULE_SOCK_DTLS
+#include "net/sock/dtls.h"
+#endif
 #include "xtimer.h"
 
 #ifdef __cplusplus
@@ -446,6 +449,13 @@ extern "C" {
  */
 #ifndef GCOAP_RESEND_BUFS_MAX
 #define GCOAP_RESEND_BUFS_MAX      (1)
+#endif
+
+/* define a common name for transport layer object, to accommodate security layer */
+#ifdef MODULE_SOCK_DTLS
+typedef sock_dtls_t coap_tl_sock_t;
+#else
+typedef sock_udp_t coap_tl_sock_t;
 #endif
 
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -691,8 +691,9 @@ static void _find_obs_memo_resource(gcoap_observe_memo_t **memo,
 
 kernel_pid_t gcoap_init(void)
 {
+#ifdef MODULE_SOCK_DTLS
     sock_dtls_init();
-
+#endif
     if (_pid != KERNEL_PID_UNDEF) {
         return -EEXIST;
     }


### PR DESCRIPTION
### Contribution description

Ideas for better code integration with DTLS. These changes remove 9 #ifdefs from gcoap.c. 

- acc8fc1 is the fix you provided for big payloads
- 051acf9 is fixes for non-DTLS mode
- ed8042d adds a more abstract name for a top level transport layer sock object
- bf99c75 consolidates the #ifdefs above the main functions for gcoap.c. Like the coap_tl_sock_t type, the implementation of the _tl_sock variable depends on whether DTLS is available. It's meant to represent the top level transport layer object.

I like this idea of having an abstract top level transport definition/object. This will help with other transports like TCP.

### Testing procedure

Works on native between two gcoap terminals, both in DTLS and non-DTLS mode.

### Issues/PRs references

N/A